### PR TITLE
Fix navigation to main quiz page after login

### DIFF
--- a/QuizardApp/Services/NavigationService.cs
+++ b/QuizardApp/Services/NavigationService.cs
@@ -24,6 +24,11 @@ namespace QuizardApp.Services
             {
                 _navigationWindow.NavigationService.Navigate(page);
             }
+            else
+            {
+                System.Diagnostics.Debug.WriteLine("Navigation failed: NavigationWindow or NavigationService is null");
+                MessageBox.Show($"Navigation failed: NavigationWindow is {(_navigationWindow == null ? "null" : "not null")}, NavigationService is {(_navigationWindow?.NavigationService == null ? "null" : "not null")}");
+            }
         }
 
         public void GoBack()

--- a/QuizardApp/ViewModels/LoginViewModel.cs
+++ b/QuizardApp/ViewModels/LoginViewModel.cs
@@ -58,15 +58,21 @@ namespace QuizardApp.ViewModels
                     if (user != null)
                     {
                         CurrentUserService.Instance.SetCurrentUser(user);
-                        Message = "Login successful!";
+                        Message = $"Login successful! User role: {user.Role}";
                         
                         if (user.Role == "teacher")
                         {
+                            Message = "Navigating to Teacher Dashboard...";
                             AppNavigationService.Instance.Navigate(new TeacherDashboardPage());
                         }
                         else if (user.Role == "student")
                         {
+                            Message = "Navigating to Student Dashboard...";
                             AppNavigationService.Instance.Navigate(new StudentDashboardPage());
+                        }
+                        else
+                        {
+                            Message = $"Unknown role: {user.Role}";
                         }
                     }
                     else


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add debugging messages to login and navigation services to diagnose why post-login navigation is failing.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The user reported that the navigation to `TeacherDashboardPage` or `StudentDashboardPage` after successful login was not occurring. These changes introduce debug output and a `MessageBox` to help identify if the user role is correctly detected, if the navigation service is being called, and if the `NavigationWindow` or its `NavigationService` is null, which could prevent the navigation from executing.

---

[Open in Web](https://www.cursor.com/agents?id=bc-bf9aab18-ef7f-46d0-9a6e-2ccf96acedfb) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-bf9aab18-ef7f-46d0-9a6e-2ccf96acedfb)