### PR TITLE
Kết nối hàm viewmodel với dashboard xaml

### DIFF
--- a/QuizardApp/ViewModels/StudentDashboardViewModel.cs
+++ b/QuizardApp/ViewModels/StudentDashboardViewModel.cs
@@ -55,7 +55,11 @@ namespace QuizardApp.ViewModels
         {
             CurrentPageTitle = "Dashboard";
             CurrentPageSubtitle = "Your learning overview";
-            CurrentView = new StudentDashboardView();
+            CurrentView = new StudentDashboardView(
+                ShowAvailableQuizzesCommand,
+                ShowSubjectsCommand,
+                ShowMyResultsCommand
+            );
         }
 
         private void ShowAvailableQuizzes()

--- a/QuizardApp/ViewModels/StudentDashboardViewViewModel.cs
+++ b/QuizardApp/ViewModels/StudentDashboardViewViewModel.cs
@@ -74,17 +74,26 @@ namespace QuizardApp.ViewModels
         public ICommand ViewAllResultsCommand { get; }
         public ICommand TakeQuizCommand { get; }
         public ICommand RefreshCommand { get; }
+        // Command điều hướng từ ViewModel cha
+        public ICommand? ShowAvailableQuizzesCommand { get; set; }
+        public ICommand? ShowSubjectsCommand { get; set; }
+        public ICommand? ShowMyResultsCommand { get; set; }
 
-        public StudentDashboardViewViewModel()
+        public StudentDashboardViewViewModel(
+            ICommand? showAvailableQuizzesCommand = null,
+            ICommand? showSubjectsCommand = null,
+            ICommand? showMyResultsCommand = null)
         {
             RecentResults = new ObservableCollection<RecentQuizResult>();
             RecommendedQuizzes = new ObservableCollection<RecommendedQuiz>();
-            
             ViewAllQuizzesCommand = new RelayCommand(ExecuteViewAllQuizzes);
             ViewAllResultsCommand = new RelayCommand(ExecuteViewAllResults);
             TakeQuizCommand = new RelayCommand(ExecuteTakeQuiz);
             RefreshCommand = new RelayCommand(ExecuteRefresh);
-            
+            // Gán command điều hướng nếu có
+            ShowAvailableQuizzesCommand = showAvailableQuizzesCommand;
+            ShowSubjectsCommand = showSubjectsCommand;
+            ShowMyResultsCommand = showMyResultsCommand;
             LoadDashboardData();
         }
 

--- a/QuizardApp/ViewModels/TeacherDashboardViewModel.cs
+++ b/QuizardApp/ViewModels/TeacherDashboardViewModel.cs
@@ -56,7 +56,12 @@ namespace QuizardApp.ViewModels
         {
             CurrentPageTitle = "Dashboard";
             CurrentPageSubtitle = "Overview of your teaching activities";
-            CurrentView = new TeacherDashboardView();
+            CurrentView = new TeacherDashboardView(
+                ShowQuizzesCommand,
+                ShowSubjectsCommand,
+                ShowResultsCommand,
+                ShowClassroomsCommand
+            );
         }
 
         private void ShowSubjects()

--- a/QuizardApp/ViewModels/TeacherDashboardViewViewModel.cs
+++ b/QuizardApp/ViewModels/TeacherDashboardViewViewModel.cs
@@ -89,19 +89,31 @@ namespace QuizardApp.ViewModels
         public ICommand ManageClassroomsCommand { get; }
         public ICommand ViewQuizDetailsCommand { get; }
         public ICommand RefreshCommand { get; }
+        // Command điều hướng từ ViewModel cha
+        public ICommand? ShowQuizzesCommand { get; set; }
+        public ICommand? ShowSubjectsCommand { get; set; }
+        public ICommand? ShowResultsCommand { get; set; }
+        public ICommand? ShowClassroomsCommand { get; set; }
 
-        public TeacherDashboardViewViewModel()
+        public TeacherDashboardViewViewModel(
+            ICommand? showQuizzesCommand = null,
+            ICommand? showSubjectsCommand = null,
+            ICommand? showResultsCommand = null,
+            ICommand? showClassroomsCommand = null)
         {
             RecentActivities = new ObservableCollection<RecentQuizActivity>();
             PopularQuizzes = new ObservableCollection<PopularQuiz>();
             SubjectStats = new ObservableCollection<SubjectStatistic>();
-            
             CreateQuizCommand = new RelayCommand(ExecuteCreateQuiz);
             ViewAllResultsCommand = new RelayCommand(ExecuteViewAllResults);
             ManageClassroomsCommand = new RelayCommand(ExecuteManageClassrooms);
             ViewQuizDetailsCommand = new RelayCommand(ExecuteViewQuizDetails);
             RefreshCommand = new RelayCommand(ExecuteRefresh);
-            
+            // Gán command điều hướng nếu có
+            ShowQuizzesCommand = showQuizzesCommand;
+            ShowSubjectsCommand = showSubjectsCommand;
+            ShowResultsCommand = showResultsCommand;
+            ShowClassroomsCommand = showClassroomsCommand;
             LoadDashboardData();
         }
 

--- a/QuizardApp/Views/StudentDashboardView.xaml
+++ b/QuizardApp/Views/StudentDashboardView.xaml
@@ -150,7 +150,7 @@
 
                         <Button Grid.Column="0" 
                                 Style="{StaticResource ActionButtonStyle}"
-                                Command="{Binding TakeQuizCommand}">
+                                Command="{Binding ShowAvailableQuizzesCommand}">
                             <StackPanel>
                                 <TextBlock Text="📝" FontSize="24" HorizontalAlignment="Center" Margin="0,0,0,5"/>
                                 <TextBlock Text="Take Quiz" HorizontalAlignment="Center"/>
@@ -159,7 +159,7 @@
 
                         <Button Grid.Column="1" 
                                 Style="{StaticResource ActionButtonStyle}"
-                                Command="{Binding BrowseSubjectsCommand}">
+                                Command="{Binding ShowSubjectsCommand}">
                             <StackPanel>
                                 <TextBlock Text="📚" FontSize="24" HorizontalAlignment="Center" Margin="0,0,0,5"/>
                                 <TextBlock Text="Browse Subjects" HorizontalAlignment="Center"/>
@@ -168,7 +168,7 @@
 
                         <Button Grid.Column="2" 
                                 Style="{StaticResource ActionButtonStyle}"
-                                Command="{Binding ViewResultsCommand}">
+                                Command="{Binding ShowMyResultsCommand}">
                             <StackPanel>
                                 <TextBlock Text="📊" FontSize="24" HorizontalAlignment="Center" Margin="0,0,0,5"/>
                                 <TextBlock Text="View Results" HorizontalAlignment="Center"/>

--- a/QuizardApp/Views/StudentDashboardView.xaml.cs
+++ b/QuizardApp/Views/StudentDashboardView.xaml.cs
@@ -8,7 +8,7 @@ namespace QuizardApp.Views
         public StudentDashboardView()
         {
             InitializeComponent();
-            DataContext = new StudentDashboardViewViewModel();
+            // DataContext = new StudentDashboardViewViewModel(); // Xóa dòng này để nhận DataContext từ cha
         }
     }
 }

--- a/QuizardApp/Views/StudentDashboardView.xaml.cs
+++ b/QuizardApp/Views/StudentDashboardView.xaml.cs
@@ -1,14 +1,15 @@
 using System.Windows.Controls;
 using QuizardApp.ViewModels;
+using System.Windows.Input; // Added for ICommand
 
 namespace QuizardApp.Views
 {
     public partial class StudentDashboardView : UserControl
     {
-        public StudentDashboardView()
+        public StudentDashboardView(ICommand? showAvailableQuizzesCommand = null, ICommand? showSubjectsCommand = null, ICommand? showMyResultsCommand = null)
         {
             InitializeComponent();
-            // DataContext = new StudentDashboardViewViewModel(); // Xóa dòng này để nhận DataContext từ cha
+            DataContext = new StudentDashboardViewViewModel(showAvailableQuizzesCommand, showSubjectsCommand, showMyResultsCommand);
         }
     }
 }

--- a/QuizardApp/Views/TeacherDashboardView.xaml
+++ b/QuizardApp/Views/TeacherDashboardView.xaml
@@ -150,7 +150,7 @@
 
                         <Button Grid.Column="0" 
                                 Style="{StaticResource QuickActionButtonStyle}"
-                                Command="{Binding CreateQuizCommand}">
+                                Command="{Binding ShowQuizzesCommand}">
                             <StackPanel>
                                 <TextBlock Text="📝" FontSize="24" HorizontalAlignment="Center" Margin="0,0,0,5"/>
                                 <TextBlock Text="Create Quiz" HorizontalAlignment="Center"/>
@@ -159,7 +159,7 @@
 
                         <Button Grid.Column="1" 
                                 Style="{StaticResource QuickActionButtonStyle}"
-                                Command="{Binding CreateClassroomCommand}">
+                                Command="{Binding ShowClassroomsCommand}">
                             <StackPanel>
                                 <TextBlock Text="🏫" FontSize="24" HorizontalAlignment="Center" Margin="0,0,0,5"/>
                                 <TextBlock Text="Create Classroom" HorizontalAlignment="Center"/>
@@ -168,7 +168,7 @@
 
                         <Button Grid.Column="2" 
                                 Style="{StaticResource QuickActionButtonStyle}"
-                                Command="{Binding ViewResultsCommand}">
+                                Command="{Binding ShowResultsCommand}">
                             <StackPanel>
                                 <TextBlock Text="📊" FontSize="24" HorizontalAlignment="Center" Margin="0,0,0,5"/>
                                 <TextBlock Text="View Results" HorizontalAlignment="Center"/>

--- a/QuizardApp/Views/TeacherDashboardView.xaml.cs
+++ b/QuizardApp/Views/TeacherDashboardView.xaml.cs
@@ -1,14 +1,15 @@
 using System.Windows.Controls;
 using QuizardApp.ViewModels;
+using System.Windows.Input;
 
 namespace QuizardApp.Views
 {
     public partial class TeacherDashboardView : UserControl
     {
-        public TeacherDashboardView()
+        public TeacherDashboardView(ICommand? showQuizzesCommand = null, ICommand? showSubjectsCommand = null, ICommand? showResultsCommand = null, ICommand? showClassroomsCommand = null)
         {
             InitializeComponent();
-            // DataContext = new TeacherDashboardViewViewModel(); // Xóa dòng này để nhận DataContext từ cha
+            DataContext = new TeacherDashboardViewViewModel(showQuizzesCommand, showSubjectsCommand, showResultsCommand, showClassroomsCommand);
         }
     }
 }

--- a/QuizardApp/Views/TeacherDashboardView.xaml.cs
+++ b/QuizardApp/Views/TeacherDashboardView.xaml.cs
@@ -8,7 +8,7 @@ namespace QuizardApp.Views
         public TeacherDashboardView()
         {
             InitializeComponent();
-            DataContext = new TeacherDashboardViewViewModel();
+            // DataContext = new TeacherDashboardViewViewModel(); // Xóa dòng này để nhận DataContext từ cha
         }
     }
 }


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Connects navigation commands from parent ViewModels to Student and Teacher Dashboard Views.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, dashboard buttons were unresponsive because the child dashboard views were not correctly bound to the navigation commands residing in their parent ViewModels. This PR passes the necessary commands from the parent ViewModel to the child ViewModel, allowing the XAML bindings to correctly invoke the navigation logic.

---

[Open in Web](https://www.cursor.com/agents?id=bc-97bc7192-3ef9-4ecd-83ad-a50535650d1a) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-97bc7192-3ef9-4ecd-83ad-a50535650d1a)