### PR TITLE
Kết nối hàm viewmodel với dashboard xaml

### DIFF
--- a/QuizardApp/ViewModels/StudentDashboardViewViewModel.cs
+++ b/QuizardApp/ViewModels/StudentDashboardViewViewModel.cs
@@ -78,6 +78,10 @@ namespace QuizardApp.ViewModels
         public ICommand? ShowAvailableQuizzesCommand { get; set; }
         public ICommand? ShowSubjectsCommand { get; set; }
         public ICommand? ShowMyResultsCommand { get; set; }
+        // Command trung gian để gọi command cha
+        public ICommand ShowAvailableQuizzesRelayCommand { get; }
+        public ICommand ShowSubjectsRelayCommand { get; }
+        public ICommand ShowMyResultsRelayCommand { get; }
 
         public StudentDashboardViewViewModel(
             ICommand? showAvailableQuizzesCommand = null,
@@ -94,6 +98,10 @@ namespace QuizardApp.ViewModels
             ShowAvailableQuizzesCommand = showAvailableQuizzesCommand;
             ShowSubjectsCommand = showSubjectsCommand;
             ShowMyResultsCommand = showMyResultsCommand;
+            // Command trung gian
+            ShowAvailableQuizzesRelayCommand = new RelayCommand(_ => ShowAvailableQuizzesCommand?.Execute(null));
+            ShowSubjectsRelayCommand = new RelayCommand(_ => ShowSubjectsCommand?.Execute(null));
+            ShowMyResultsRelayCommand = new RelayCommand(_ => ShowMyResultsCommand?.Execute(null));
             LoadDashboardData();
         }
 

--- a/QuizardApp/Views/StudentDashboardView.xaml
+++ b/QuizardApp/Views/StudentDashboardView.xaml
@@ -150,7 +150,7 @@
 
                         <Button Grid.Column="0" 
                                 Style="{StaticResource ActionButtonStyle}"
-                                Command="{Binding ShowAvailableQuizzesCommand}">
+                                Command="{Binding ShowAvailableQuizzesRelayCommand}">
                             <StackPanel>
                                 <TextBlock Text="📝" FontSize="24" HorizontalAlignment="Center" Margin="0,0,0,5"/>
                                 <TextBlock Text="Take Quiz" HorizontalAlignment="Center"/>
@@ -159,7 +159,7 @@
 
                         <Button Grid.Column="1" 
                                 Style="{StaticResource ActionButtonStyle}"
-                                Command="{Binding ShowSubjectsCommand}">
+                                Command="{Binding ShowSubjectsRelayCommand}">
                             <StackPanel>
                                 <TextBlock Text="📚" FontSize="24" HorizontalAlignment="Center" Margin="0,0,0,5"/>
                                 <TextBlock Text="Browse Subjects" HorizontalAlignment="Center"/>
@@ -168,7 +168,7 @@
 
                         <Button Grid.Column="2" 
                                 Style="{StaticResource ActionButtonStyle}"
-                                Command="{Binding ShowMyResultsCommand}">
+                                Command="{Binding ShowMyResultsRelayCommand}">
                             <StackPanel>
                                 <TextBlock Text="📊" FontSize="24" HorizontalAlignment="Center" Margin="0,0,0,5"/>
                                 <TextBlock Text="View Results" HorizontalAlignment="Center"/>


### PR DESCRIPTION
Connect dashboard action buttons to their respective navigation commands.

The dashboard views (`StudentDashboardView`, `TeacherDashboardView`) were setting their own `DataContext` to child ViewModels (`StudentDashboardViewViewModel`, `TeacherDashboardViewViewModel`), which lacked access to the main navigation commands defined in the parent ViewModels (`StudentDashboardViewModel`, `TeacherDashboardViewModel`). This PR passes the parent commands to the child ViewModels and updates XAML bindings, allowing the buttons to correctly trigger navigation.

---

[Open in Web](https://www.cursor.com/agents?id=bc-97bc7192-3ef9-4ecd-83ad-a50535650d1a) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-97bc7192-3ef9-4ecd-83ad-a50535650d1a)